### PR TITLE
Build: Use DUCKDB_REPO variable where available

### DIFF
--- a/android/Makefile
+++ b/android/Makefile
@@ -47,7 +47,7 @@ clean:
 	make -C $(DUCKDB_DIR) clean
 
 duckdb: ## Shallow clone DuckDb repo and checkout specific commit
-	git clone --depth 1 --branch "$(VERSION)" https://github.com/duckdb/duckdb $(DUCKDB_DIR)
+	git clone --depth 1 --branch "$(VERSION)" $(DUCKDB_REPO) $(DUCKDB_DIR)
 
 build_%: duckdb
 	@mkdir -p $(BUILD_DIR)/extension_configuration

--- a/android/Makefile.spatial
+++ b/android/Makefile.spatial
@@ -55,7 +55,7 @@ clean:
 	make -C $(DUCKDB_DIR) clean
 
 duckdb: ## Shallow clone DuckDb repo and checkout specific commit
-	git clone --depth 1 --branch "$(VERSION)" https://github.com/duckdb/duckdb $(DUCKDB_DIR)
+	git clone --depth 1 --branch "$(VERSION)" $(DUCKDB_REPO) $(DUCKDB_DIR)
 	cp extension_config_local.cmake $(EXTENSION_DIR)
 	mkdir -p $(PATCHES_DIR)
 	cp android_spatial.patch $(PATCHES_DIR)

--- a/ios/Makefile
+++ b/ios/Makefile
@@ -1,4 +1,5 @@
 VERSION = v1.1.3
+DUCKDB_REPO = https://github.com/duckdb/duckdb
 DUCKDB_DIR = ./duckdb
 IOS_PLATFORM_SIMULATOR = iPhoneSimulator
 IOS_PLATFORM_DEVICE = iPhoneOS
@@ -20,7 +21,7 @@ clean: ## Clean duckdb build
 	make -C $(DUCKDB_DIR) clean;
 
 duckdb: ## Clone DuckDb repo and apply patch
-	git clone --depth 1 --branch "$(VERSION)" https://github.com/duckdb/duckdb $(DUCKDB_DIR)
+	git clone --depth 1 --branch "$(VERSION)" $(DUCKDB_REPO) $(DUCKDB_DIR)
 	git -C $(DUCKDB_DIR) apply ../changes.patch
 
 sim_x64: duckdb ## Simulator build for ARM64

--- a/ios/Makefile.spatial
+++ b/ios/Makefile.spatial
@@ -31,7 +31,7 @@ clean: ## Clean duckdb build
 	make -C $(DUCKDB_DIR) clean
 
 duckdb: ## Clone DuckDb repo and apply patch
-	git clone --depth 1 --branch "$(VERSION)" https://github.com/duckdb/duckdb $(DUCKDB_DIR)
+	git clone --depth 1 --branch "$(VERSION)" $(DUCKDB_REPO) $(DUCKDB_DIR)
 	git -C $(DUCKDB_DIR) apply ../changes.patch
 	cp extension_config_local.cmake $(EXTENSION_DIR)
 

--- a/linux/Makefile
+++ b/linux/Makefile
@@ -1,4 +1,5 @@
 VERSION = v1.1.3
+DUCKDB_REPO = https://github.com/duckdb/duckdb
 DUCKDB_DIR = ./duckdb
 
 # common environment variables
@@ -18,7 +19,7 @@ clean:
 	make -C $(DUCKDB_DIR) clean;
 
 duckdb: ## Clone DuckDb repo and apply patch
-	git clone --depth 1 --branch "$(VERSION)" https://github.com/duckdb/duckdb $(DUCKDB_DIR)
+	git clone --depth 1 --branch "$(VERSION)" $(DUCKDB_REPO) $(DUCKDB_DIR)
 
 release: duckdb ## x64 linux build
 	@export DUCKDB_PLATFORM=linux_amd64; \

--- a/linux/Makefile.spatial
+++ b/linux/Makefile.spatial
@@ -35,7 +35,7 @@ clean:
 	make -C $(DUCKDB_DIR) clean
 
 duckdb: ## Shallow clone DuckDb repo and checkout specific commit
-	git clone --depth 1 --branch "$(VERSION)" https://github.com/duckdb/duckdb $(DUCKDB_DIR)
+	git clone --depth 1 --branch "$(VERSION)" $(DUCKDB_REPO) $(DUCKDB_DIR)
 	cp extension_config_local.cmake $(EXTENSION_DIR)
 
 build: duckdb ## Build for specific architecture

--- a/macos/Makefile
+++ b/macos/Makefile
@@ -1,4 +1,5 @@
 VERSION = v1.1.3
+DUCKDB_REPO = https://github.com/duckdb/duckdb
 DUCKDB_DIR = ./duckdb
 
 # common environment variables
@@ -19,7 +20,7 @@ clean:
 	make -C $(DUCKDB_DIR) clean;
 
 duckdb: ## Clone DuckDb repo and apply patch
-	git clone --depth 1 --branch "$(VERSION)" https://github.com/duckdb/duckdb $(DUCKDB_DIR)
+	git clone --depth 1 --branch "$(VERSION)" $(DUCKDB_REPO) $(DUCKDB_DIR)
 
 release_x64: duckdb ## x64 osx build
 	@export OSX_BUILD_ARCH='x86_64'; \

--- a/macos/Makefile.spatial
+++ b/macos/Makefile.spatial
@@ -24,7 +24,7 @@ clean:
 	make -C $(DUCKDB_DIR) clean
 
 duckdb: ## Shallow clone DuckDb repo and checkout specific commit
-	git clone --depth 1 --branch "$(VERSION)" https://github.com/duckdb/duckdb $(DUCKDB_DIR)
+	git clone --depth 1 --branch "$(VERSION)" $(DUCKDB_REPO) $(DUCKDB_DIR)
 	cp extension_config_local.cmake $(EXTENSION_DIR)
 
 $(LIB_DIR)/libduckdb_x64.dylib: duckdb ## x64 osx build


### PR DESCRIPTION
Several build files have a configurable `DUCKDB_REPO` variable but the `git clone` has a hard-coded repository address to `https://github.com/duckdb/duckdb`. This PR fixes this and it adds the variable in the files where it's missing.