### PR TITLE
Remove Flutter SDK requirement for pure-Dart use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.4.5
+
+- remove the Flutter SDK requirement so the package can be used from pure Dart
+  projects (server-side, CLI, Docker); Flutter apps are unaffected
+
 ## 1.4.4
 
 - upgrade duckdb binaries to 1.4.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,11 @@
 name: dart_duckdb
 description: DuckDB for macOS, iOS, Android, Linux, Windows, and Web
-version: 1.4.4
+version: 1.4.5
 homepage: https://github.com/TigerEyeLabs/duckdb-dart
 issue_tracker: https://github.com/TigerEyeLabs/duckdb-dart/issues
 
 environment:
   sdk: ">=3.6.0 <4.0.0"
-  flutter: ">=3.35.3 <=4.0.0"
 
 dependencies:
   async: ^2.11.0
@@ -22,10 +21,6 @@ dependencies:
 
 dev_dependencies:
   ffigen: ^14.0.1
-  flutter_test:
-    sdk: flutter
-  flutter_web_plugins:
-    sdk: flutter
   lints: ^5.1.1
   test: ^1.26.3
 


### PR DESCRIPTION
The flutter environment constraint blocked installation on standalone Dart SDKs, breaking server-side apps, CLI tools and Docker test images. No Flutter API is used at runtime - the library is dart:ffi on native and dart:js_interop on web. Flutter is only the build system that bundles libduckdb, driven by the flutter.plugin block, which is kept.

flutter_test and flutter_web_plugins are also dropped; both were unused.

Fixes #41